### PR TITLE
Added PFFFT support for AudioFFT

### DIFF
--- a/AudioFFT.cpp
+++ b/AudioFFT.cpp
@@ -941,7 +941,7 @@ public:
         cmplx[1] = re[n2]; // nyquist magnitude
         
         pffft_transform_ordered(setup, cmplx, data, nullptr, PFFFT_BACKWARD);
-        detail::ScaleBuffer(data, data, 1.0f/float(2*n), (size_t)n);
+        detail::ScaleBuffer(data, data, 1.0f/float(n), (size_t)n);
     }
     
 private:


### PR DESCRIPTION
PFFFT should be faster than the default Ooura implementation and is very portable and supports multiple types of SIMD instruction sets including ARM NEON.